### PR TITLE
Use package version instead of building from sources

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,4 +11,4 @@ supports 'redhat', '~> 6.0'
 supports 'amazon'
 
 depends 'supervisor', '~> 0.4'
-depends 'golang',     '~> 1.5'
+depends 'packagecloud', '~> 0.2.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,40 +6,13 @@
 #
 
 include_recipe 'supervisor'
-include_recipe 'golang'
 
-PATH = '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/go/bin:/opt/go/bin'
-
-GO_BIN = node['go']['bin']
-GO_PATH = node['go']['gopath']
-GO_OWNER = node['go']['owner']
-GO_GROUP = node['go']['group']
-
-[
-  'go get -u github.com/jteeuwen/go-bindata/...',
-  'go get -u -d github.com/graphite-ng/carbon-relay-ng/...'
-].each do |cmd|
-  execute cmd do
-    user GO_OWNER
-    group GO_GROUP
-    environment(
-      'GOPATH' => GO_PATH,
-      'GOBIN' => GO_BIN,
-      'PATH' => PATH
-    )
-  end
+packagecloud_repo 'raintank/raintank' do
+  type 'deb'
 end
 
-execute 'make install' do
-  user GO_OWNER
-  group GO_GROUP
-  cwd "#{GO_PATH}/src/github.com/graphite-ng/carbon-relay-ng"
-  environment(
-    'GOPATH' => GO_PATH,
-    'GOBIN' => GO_BIN,
-    'PATH' => PATH
-  )
-  not_if { ::File.exist?("#{GO_BIN}/carbon-relay-ng") }
+package 'carbon-relay-ng' do
+  version '0.8-1'
 end
 
 SPOOL_ENABLED = node['carbon-relay-ng']['spool']['enabled']
@@ -77,7 +50,7 @@ SUP_STDERR_LOG = node['carbon-relay-ng']['supervisor']['stderr_logfile']
 
 # TODO: add extra supervisor service configs
 supervisor_service 'carbon-relay-ng' do
-  command "#{GO_BIN}/carbon-relay-ng #{CARBON_CONF_DIR}/carbon-relay-ng.ini"
+  command "carbon-relay-ng #{CARBON_CONF_DIR}/carbon-relay-ng.ini"
   process_name SUP_PROC_NAME
   stdout_logfile "#{CARBON_LOG_DIR}/#{SUP_STDOUT_LOG}"
   stderr_logfile "#{CARBON_LOG_DIR}/#{SUP_STDERR_LOG}"

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -4,28 +4,8 @@ describe 'carbon-relay-ng::default' do
   cached(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
   cached(:node) { chef_run.node }
 
-  before do
-    stub_command("/usr/local/go/bin/go version | grep \"go1.4 \"").and_return(true)
-  end
-
   it 'include the supervisor recipe' do
     expect(chef_run).to include_recipe('supervisor')
-  end
-
-  it 'include the golang::packages recipe' do
-    expect(chef_run).to include_recipe('golang')
-  end
-
-  it 'install the go-bindata binary' do
-    expect(chef_run).to run_execute('go get -u github.com/jteeuwen/go-bindata/...')
-  end
-
-  it 'gets the carbon-relay-ng source' do
-    expect(chef_run).to run_execute('go get -u -d github.com/graphite-ng/carbon-relay-ng/...')
-  end
-
-  it 'install the carbon-relay-ng binary' do
-    expect(chef_run).to run_execute('make install')
   end
 
   it 'creates the spool directory' do


### PR DESCRIPTION
Hi. I had some problems with building carbon-relay-ng from sources. Cookbooks has been broken almost every time I've tried to update.

This pull request will stop all suffering. Simple and clean deb package installation. 